### PR TITLE
fix: local time timer only trigger once

### DIFF
--- a/CustomRPC/MainForm.cs
+++ b/CustomRPC/MainForm.cs
@@ -202,7 +202,7 @@ namespace CustomRPC
             restartTimer.Elapsed += RestartTimer_Elapsed;
 
             // Setting up a midnight presence update timer
-            localTimeTimer.AutoReset = false;
+            localTimeTimer.AutoReset = true;
             localTimeTimer.Elapsed += LocalTimeTimer_Elapsed;
 
             // If we supply a preset file to import on load, load it right away


### PR DESCRIPTION
As discussed in #256, the timer only triggers once. According to https://learn.microsoft.com/en-us/dotnet/api/system.timers.timer.autoreset?view=net-8.0, I suspect we can set `AutoReset = true` to avoid this, since from the doc:

> false if it should raise the [Elapsed](https://learn.microsoft.com/en-us/dotnet/api/system.timers.timer.elapsed?view=net-8.0#system-timers-timer-elapsed) event only once, after the first time the interval elapses
